### PR TITLE
fix quoquote

### DIFF
--- a/mc2.sublime-syntax
+++ b/mc2.sublime-syntax
@@ -81,11 +81,11 @@ contexts:
       scope: constant.numeric.mc2
 
   inline_strings:
-    - match: (?<!\S)('.*')(?!\S)
+    - match: (?<!\S)('[^']*')(?!\S)
       scope: string.quoted.double.mc2
 
   inline_double_quoted_strings:
-    - match: (?<!\S)(".*")(?!\S)
+    - match: (?<!\S)("[^"]*")(?!\S)
       scope: string.quoted.double.mc2
 
               


### PR DESCRIPTION
previously, if there were multiple strings in a line, the string regexp matched the expression between the first quote of the first string and the last quote of the last string
